### PR TITLE
Fix missing home route

### DIFF
--- a/buildmart-online/backend/buildmart/urls.py
+++ b/buildmart-online/backend/buildmart/urls.py
@@ -9,6 +9,7 @@ print("### buildmart.urls IMPORTED. urlpatterns =", file=sys.stderr)
 pprint.pprint([], stream=sys.stderr)  # جا برای بعد
 
 urlpatterns = [
+    path("",         index, name="index"),
     path("api/",      include("catalog.urls")),
     path("admin/",    admin.site.urls),
     path("api/catalog/", include("catalog.urls")),  # API


### PR DESCRIPTION
## Summary
- add `index` path to Django URL configuration

## Testing
- `python manage.py test` *(no tests found)*
- `npm run dev` *(shows Vite dev server starting)*

------
https://chatgpt.com/codex/tasks/task_e_685f7f522b8483268b46833f385177e0